### PR TITLE
Issue 4

### DIFF
--- a/classes/receiver/message_receiver.php
+++ b/classes/receiver/message_receiver.php
@@ -7,13 +7,14 @@ use tool_messagebroker\message\immutable_message;
  * Interface that message receivers must implement.
  */
 interface message_receiver {
-    static function instance(): message_receiver;
-    function process_message(immutable_message $message): bool;
+    public static function instance(): self;
+
+    public function process_message(immutable_message $message): bool;
 
     /**
      * @return string a processing style from \tool_messagebroker\receiver\processing_style
      */
-    function get_preferred_message_processing_method(): string;
+    public function get_preferred_message_processing_method(): string;
 
-    function get_registered_topic(): string;
+    public function get_registered_topic(): string;
 }

--- a/datastores/standarddb/classes/durable_dao_factory.php
+++ b/datastores/standarddb/classes/durable_dao_factory.php
@@ -7,7 +7,7 @@ use tool_messagebroker\message\durable_dao_interface;
 class durable_dao_factory implements durable_dao_factory_interface {
 
     static function make_durable_dao($variant): durable_dao_interface {
-        // TODO: Implement make_durable_dao() method.
+        return new durable_dao;
     }
 
     static function make_specific_durable_dao($variant, $variantdata): durable_dao_interface {


### PR DESCRIPTION
# Testing
1. Place the following in the root of your Moodle install and call it test.php:
```
<?php

require_once('config.php');

$message = new tool_messagebroker\message\message();
$message->set_topic('cool.movies');
$mode = get_config('tool_messagebroker', 'receivemode');
$processor = tool_messagebroker\message_processor::instance($mode);
$processor->process_message($message);
````
2. Add the following in the root of any Moodle plugin and call it messagebroker.php:
```
<?php

function [FRANKENSTYLE PREFIX]_build_message_receivers() {
    return [
        new class implements tool_messagebroker\receiver\message_receiver {
            public static function instance(): self {
                return new self();
            }

            public function process_message(tool_messagebroker\message\immutable_message $message): bool {
                echo "Processed";
                return true;
            }

           public function get_preferred_message_processing_method(): string {
               return tool_messagebroker\receiver\processing_style::EPHEMERAL;
           }

           public function get_registered_topic(): string {
               return "/movies/";
           }
        }
    ];
}
````
3. Browse to "Site administration" > "Plugins" > "Admin tools" > "Message broker"
4. Set "Message receiving mode" to "Receiver preference"
5. Browse to http://[YOUR MOODLE]/test.php
6. **Verify** the text "Processed" is visible with no errors
7. Go back to "Site administration" > "Plugins" > "Admin tools" > "Message broker" and set "Message receiving mode" to "Ephemeral"
8. Browse to http://[YOUR MOODLE]/test.php
9. **Verify** the text "Processed" is visible with no errors.
10. Go back to "Site administration" > "Plugins" > "Admin tools" > "Message broker" and set "Message receiving mode" to "Durable"
11. Browse to http://[YOUR MOODLE]/test.php
12. **Verify** the text "Processed" is **not** visible (this is because the message should be persisted and later checked in the background as part of the scheduled task `durable_message_processor`

Fixes #4 