### PR TITLE
Issue 7

### DIFF
--- a/classes/durable_message_processor.php
+++ b/classes/durable_message_processor.php
@@ -18,7 +18,7 @@ class durable_message_processor extends scheduled_task {
         $maxmessagecount = 10; // TODO: replace with setting.
         $messages = $dao->get_upto_n_unprocessed_messages($maxmessagecount);
         foreach ($messages as $message) {
-            $dao->update_processing_time($message->get_id(), time());
+            $dao->notify_processing_attempt($message->get_id());
             $processor->process_message($message);
             $dao->mark_message_as_processed($message->get_id());
         }

--- a/classes/durable_message_processor.php
+++ b/classes/durable_message_processor.php
@@ -12,7 +12,7 @@ class durable_message_processor extends scheduled_task {
     }
 
     public function execute() {
-        $daovariant = 'messagebrokerdatastore_standarddb'; // TODO: replace with setting.
+        $daovariant = 'mbdatastore_standarddb'; // TODO: replace with setting.
         $dao = durable_dao_factory::make_durable_dao($daovariant);
         $processor = message_processor::instance();
         $maxmessagecount = 10; // TODO: replace with setting.

--- a/classes/message/durable_dao_factory.php
+++ b/classes/message/durable_dao_factory.php
@@ -1,14 +1,25 @@
 <?php
 namespace tool_messagebroker\message;
 
-use messagebrokerdatastore_standarddb\durable_dao;
+use coding_exception;
 
 class durable_dao_factory implements durable_dao_factory_interface {
-    static function make_durable_dao($variant): durable_dao {
 
+    public static function make_durable_dao($variant): durable_dao_interface {
+        $classname = 'mbdatastore_' . $variant . '\durable_dao_factory';
+        if (!class_exists($classname)) {
+            throw new coding_exception('Durable DAO factory not implemented for ' . $variant);
+        }
+
+        return $classname::make_durable_dao($variant);
     }
 
-    static function make_specific_durable_dao($variant, $variantdata): durable_dao {
+    public static function make_specific_durable_dao($variant, $variantdata): durable_dao_interface {
+        $classname = 'mbdatastore_' . $variant . '\durable_dao_factory';
+        if (!class_exists($classname)) {
+            throw new coding_exception('Durable DAO factory not implemented for ' . $variant);
+        }
 
+        return $classname::make_specific_durable_dao($variant, $variantdata);
     }
 }

--- a/classes/message/durable_dao_factory_interface.php
+++ b/classes/message/durable_dao_factory_interface.php
@@ -2,7 +2,7 @@
 namespace tool_messagebroker\message;
 
 interface durable_dao_factory_interface {
-    static function make_durable_dao($variant): durable_dao_interface;
+    public static function make_durable_dao($variant): durable_dao_interface;
 
-    static function make_specific_durable_dao($variant, $variantdata): durable_dao_interface;
+    public static function make_specific_durable_dao($variant, $variantdata): durable_dao_interface;
 }

--- a/classes/message/durable_dao_interface.php
+++ b/classes/message/durable_dao_interface.php
@@ -4,9 +4,9 @@ namespace tool_messagebroker\message;
 interface durable_dao_interface {
     function write_new_message(immutable_message $message);
 
-    function update_processing_time(int $id, int $processingtime);
+    function notify_processing_attempt(string $id);
 
-    function mark_message_as_processed(int $id) ;
+    function mark_message_as_processed(string $id) ;
 
     /**
      * @param int $n

--- a/classes/message/immutable_message.php
+++ b/classes/message/immutable_message.php
@@ -4,7 +4,7 @@ namespace tool_messagebroker\message;
 use stdClass;
 
 class immutable_message {
-    protected int $id = 0;
+    protected string $id = '';
     protected string $topic;
     protected stdClass $body;
     protected bool $processingcomplete;
@@ -17,7 +17,7 @@ class immutable_message {
     /**
      * @return int
      */
-    public function get_id(): int {
+    public function get_id(): string {
         return $this->id;
     }
 

--- a/classes/message/message.php
+++ b/classes/message/message.php
@@ -5,10 +5,10 @@ use stdClass;
 
 class message extends immutable_message {
     /**
-     * @param int $id
+     * @param string $id
      * @return self
      */
-    public function set_id(int $id): self {
+    public function set_id(string $id): self {
         $this->id = $id;
         return $this;
     }

--- a/classes/message/message.php
+++ b/classes/message/message.php
@@ -6,45 +6,45 @@ use stdClass;
 class message extends immutable_message {
     /**
      * @param int $id
-     * @return immutable_message
+     * @return self
      */
-    public function set_id(int $id): immutable_message {
+    public function set_id(int $id): self {
         $this->id = $id;
         return $this;
     }
 
     /**
      * @param string $topic
-     * @return immutable_message
+     * @return self
      */
-    public function set_topic(string $topic): immutable_message {
+    public function set_topic(string $topic): self {
         $this->topic = $topic;
         return $this;
     }
 
     /**
      * @param stdClass $body
-     * @return immutable_message
+     * @return self
      */
-    public function set_body(stdClass $body): immutable_message {
+    public function set_body(stdClass $body): self {
         $this->body = $body;
         return $this;
     }
 
     /**
      * @param bool $processingcomplete
-     * @return immutable_message
+     * @return self
      */
-    public function set_processingcomplete(bool $processingcomplete): immutable_message {
+    public function set_processingcomplete(bool $processingcomplete): self {
         $this->processingcomplete = $processingcomplete;
         return $this;
     }
 
     /**
      * @param int $lastprocessed
-     * @return immutable_message
+     * @return self
      */
-    public function set_lastprocessed(int $lastprocessed): immutable_message {
+    public function set_lastprocessed(int $lastprocessed): self {
         $this->lastprocessed = $lastprocessed;
         return $this;
     }

--- a/classes/message_processor.php
+++ b/classes/message_processor.php
@@ -6,7 +6,7 @@ use tool_messagebroker\message\durable_dao_interface;
 use tool_messagebroker\message\immutable_message;
 use tool_messagebroker\receiver\message_receiver;
 use tool_messagebroker\receiver\processing_style;
-use messagebrokerdatastore_standarddb\durable_dao_factory;
+use tool_messagebroker\message\durable_dao_factory;
 
 class message_processor {
     /**
@@ -82,7 +82,7 @@ class message_processor {
         // All receivers must be treated as ephemeral.
         if ($this->receivermode === processing_style::EPHEMERAL) {
             $ephemeralresults = array_map(
-                fn (message_receiver $receiver): bool => $receiver->process_message($message),
+                fn(message_receiver $receiver): bool => $receiver->process_message($message),
                 $receivers
             );
         }

--- a/classes/plugininfo/mbdatastore.php
+++ b/classes/plugininfo/mbdatastore.php
@@ -7,11 +7,11 @@ namespace tool_messagebroker\plugininfo;
 use core\plugininfo\base;
 
 /**
- * Databroker connector subplugin info.
+ * Message Broker data store subplugin info.
  *
  * @package   tool_messagebroker
  * @copyright 2023 Monash University
  * @author    Cameron Ball <cameronball@catalyst-au.net>
  */
-class messagebrokerdatastore extends base {
+class mbdatastore extends base {
 }

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -1,1 +1,24 @@
 <?php
+
+declare(strict_types=1);
+
+namespace tool_messagebroker\privacy;
+
+use core_privacy\local\metadata\null_provider;
+
+/**
+ * Privacy provider.
+ *
+ * @package   tool_messagebroker
+ * @copyright 2023 Monash University
+ * @author    Cameron Ball <cameronball@catalyst-au.net>
+ */
+class provider implements null_provider {
+
+    /**
+     * Constructor.
+     */
+    public static function get_reason(): string {
+        return 'privacy:metadata';
+    }
+}

--- a/datastores/standarddb/classes/durable_dao.php
+++ b/datastores/standarddb/classes/durable_dao.php
@@ -26,7 +26,7 @@ class durable_dao implements durable_dao_interface {
         );
     }
 
-    public function update_processing_time(int $id, int $processingtime) {
+    public function notify_processing_attempt(string $id) {
         global $DB;
         $now = time();
 
@@ -39,7 +39,7 @@ class durable_dao implements durable_dao_interface {
         );
     }
 
-    public function mark_message_as_processed(int $id) {
+    public function mark_message_as_processed(string $id) {
         global $DB;
         $now = time();
 

--- a/datastores/standarddb/classes/durable_dao.php
+++ b/datastores/standarddb/classes/durable_dao.php
@@ -1,28 +1,84 @@
 <?php
-namespace messagebrokerdatastore_standarddb;
+namespace mbdatastore_standarddb;
 
+use stdClass;
 use tool_messagebroker\message\durable_dao_interface;
 use tool_messagebroker\message\immutable_message;
+use tool_messagebroker\message\message;
 
 class durable_dao implements durable_dao_interface {
 
-    function write_new_message(immutable_message $message) {
-        // TODO: Implement write_new_message() method.
+    const TABLE = 'mbdatastore_standarddb_msg';
+
+    public function write_new_message(immutable_message $message) {
+        global $DB;
+        $now = time();
+
+        $DB->insert_record(
+            self::TABLE,
+            (object)[
+                'topic' => $message->get_topic(),
+                'body' => json_encode($message->get_body()),
+                'timecreated' => $now,
+                'lastprocessed' => $now,
+                'completed' => 0
+            ]
+        );
     }
 
-    function update_processing_time(int $id, int $processingtime) {
-        // TODO: Implement update_processing_time() method.
+    public function update_processing_time(int $id, int $processingtime) {
+        global $DB;
+        $now = time();
+
+        $DB->update_record(
+            self::TABLE,
+            (object)[
+                'id' => $id,
+                'lastprocessed' => $now
+            ]
+        );
     }
 
-    function mark_message_as_processed(int $id) {
-        // TODO: Implement mark_message_as_processed() method.
+    public function mark_message_as_processed(int $id) {
+        global $DB;
+        $now = time();
+
+        $DB->update_record(
+            self::TABLE,
+            (object)[
+                'id' => $id,
+                'lastprocessed' => $now,
+                'completed' => 1
+            ]
+        );
     }
 
-    function get_upto_n_unprocessed_messages(int $n): array {
-        // TODO: Implement get_upto_n_unprocessed_messages() method.
+    public function get_upto_n_unprocessed_messages(int $n): array {
+        global $DB;
+        $records = $DB->get_records_list(
+            self::TABLE,
+            'completed',
+            ['0'],
+            'id DESC',
+            '*',
+            0,
+            $n
+        );
+
+        return array_map(
+            fn(stdClass $record): immutable_message => (new message)
+                ->set_id($record->id)
+                ->set_topic($record->topic)
+                ->set_body(json_decode($record->body))
+                ->set_lastprocessed($record->lastprocessed)
+                ->set_processingcomplete(false),
+            $records
+        );
     }
 
-    function purge_completed_messages() {
+    public function purge_completed_messages() {
+        global $DB;
 
+        $DB->delete_records(self::TABLE, ['completed' => 1]);
     }
 }

--- a/datastores/standarddb/classes/durable_dao_factory.php
+++ b/datastores/standarddb/classes/durable_dao_factory.php
@@ -1,16 +1,16 @@
 <?php
-namespace messagebrokerdatastore_standarddb;
+namespace mbdatastore_standarddb;
 
 use tool_messagebroker\message\durable_dao_factory_interface;
 use tool_messagebroker\message\durable_dao_interface;
 
 class durable_dao_factory implements durable_dao_factory_interface {
 
-    static function make_durable_dao($variant): durable_dao_interface {
+    public static function make_durable_dao($variant): durable_dao_interface {
         return new durable_dao;
     }
 
-    static function make_specific_durable_dao($variant, $variantdata): durable_dao_interface {
-        // TODO: Implement make_specific_durable_dao() method.
+    public static function make_specific_durable_dao($variant, $variantdata): durable_dao_interface {
+        return new durable_dao;
     }
 }

--- a/datastores/standarddb/classes/durable_message_cleaner.php
+++ b/datastores/standarddb/classes/durable_message_cleaner.php
@@ -1,5 +1,5 @@
 <?php
-namespace messagebrokerdatastore_standarddb;
+namespace mbdatastore_standarddb;
 
 use core\task\scheduled_task;
 
@@ -10,7 +10,7 @@ class durable_message_cleaner extends scheduled_task {
     }
 
     public function execute() {
-        $dao = durable_dao_factory::make_durable_dao('messagebrokerdatastore_standarddb');
+        $dao = durable_dao_factory::make_durable_dao('mbdatastore_standarddb');
         $dao->purge_completed_messages();
     }
 }

--- a/datastores/standarddb/classes/privacy/provider.php
+++ b/datastores/standarddb/classes/privacy/provider.php
@@ -1,1 +1,24 @@
 <?php
+
+declare(strict_types=1);
+
+namespace mbdatastore_standarddb\privacy;
+
+use core_privacy\local\metadata\null_provider;
+
+/**
+ * Privacy provider.
+ *
+ * @package   mbdatastore_standarddb
+ * @copyright 2023 Monash University
+ * @author    Cameron Ball <cameronball@catalyst-au.net>
+ */
+class provider implements null_provider {
+
+    /**
+     * Constructor.
+     */
+    public static function get_reason(): string {
+        return 'privacy:metadata';
+    }
+}

--- a/datastores/standarddb/db/install.xml
+++ b/datastores/standarddb/db/install.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<XMLDB PATH="admin/tool/messagebroker/datastores/standarddb/db" VERSION="20230828" COMMENT="XMLDB file for Moodle admin/tool/messagebroker/datastores/standarddb"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="../../../../../lib/xmldb/xmldb.xsd"
+>
+  <TABLES>
+    <TABLE NAME="mbdatastore_standarddb_msg" COMMENT="Messages currently being processed (or have failed to process).">
+      <FIELDS>
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="topic" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="body" TYPE="text" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+        <FIELD NAME="lastprocessed" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+        <FIELD NAME="completed" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+      </FIELDS>
+      <KEYS>
+          <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+      </KEYS>
+    </TABLE>
+  </TABLES>
+</XMLDB>

--- a/datastores/standarddb/db/tasks.php
+++ b/datastores/standarddb/db/tasks.php
@@ -1,7 +1,7 @@
 <?php
 $tasks = [
     [
-        'classname' => 'messagebrokerdatastore_standarddb\durable_message_cleaner',
+        'classname' => 'mbdatastore_standarddb\durable_message_cleaner',
         'blocking' => 0,
         'minute' => 'R',
         'hour' => '*/3',

--- a/datastores/standarddb/lang/en/mbdatastore_standarddb.php
+++ b/datastores/standarddb/lang/en/mbdatastore_standarddb.php
@@ -1,9 +1,9 @@
 <?php
 
 /**
- * Strings for messagebrokerdatastore_standarddb.
+ * Strings for mbdatastore_standarddb.
  *
- * @package   messagebrokerdatastore_standarddb
+ * @package   mbdatastore_standarddb
  * @copyright 2023 Monash University
  * @author    Cameron Ball <cameronball@catalyst-au.net>
  */

--- a/datastores/standarddb/version.php
+++ b/datastores/standarddb/version.php
@@ -2,7 +2,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 /** @var stdClass $plugin */
-$plugin->component = 'messagebrokerdatastore_standarddb';
+$plugin->component = 'mbdatastore_standarddb';
 $plugin->version = 2023060500;
 $plugin->requires = 2020061505;
 $plugin->maturity = MATURITY_ALPHA;

--- a/db/subplugins.json
+++ b/db/subplugins.json
@@ -1,6 +1,6 @@
 {
     "plugintypes": {
         "messagebrokerconnector": "admin\/tool\/messagebroker\/connectors",
-        "messagebrokerdatastore": "admin\/tool\/messagebroker\/datastores"
+        "mbdatastore": "admin\/tool\/messagebroker\/datastores"
     }
 }

--- a/settings.php
+++ b/settings.php
@@ -20,9 +20,9 @@ if ($hassiteconfig) {
 
 
     if ($ADMIN->fulltree) {
-        $datastoreplugins = array_keys(core_plugin_manager::instance()->get_installed_plugins('messagebrokerdatastore'));
+        $datastoreplugins = array_keys(core_plugin_manager::instance()->get_installed_plugins('mbdatastore'));
         $datastoreselections = array_map(
-            fn(string $pluginname): string => get_string('pluginname', 'messagebrokerdatastore_' . $pluginname),
+            fn(string $pluginname): string => get_string('pluginname', 'mbdatastore_' . $pluginname),
             array_combine($datastoreplugins, $datastoreplugins)
         );
 


### PR DESCRIPTION
# Testing
1. Place the following script in the root of your Moodle install, call it test.php
```
<?php

require_once('config.php');

$variant = get_config('tool_messagebroker', 'datastore');
$message = (new tool_messagebroker\message\received_message)
               ->set_topic('cool.movies')
               ->set_body((object)["some" => "data", "somemore" => "differentdata"]);

$dao = tool_messagebroker\message\durable_dao_factory::make_durable_dao($variant);
$dao->write_new_message($message);
```
2. Browse to http://[YOUR MOODLE]/test.php
3. Inspect the DB and **verify** a record exists in the `mdl_mbdatastore_standarddb_msg` table` 
4. Refresh the script a couple of times to add more messages to the table
5. Replace test.php with the following:
```
<?php

require_once('config.php');

$variant = get_config('tool_messagebroker', 'datastore');
$dao = tool_messagebroker\message\durable_dao_factory::make_durable_dao($variant);
$messages = $dao->get_upto_n_unprocessed_messages(2);

echo '<pre>';
print_r($messages);
echo '</pre>';
```
6. Browse to test.php again and **verify** it lists the most recent two messages
7. Change the argument provided to `$messages = $dao->get_upto_n_unprocessed_messages(2);` and reload the page
8. **Verify** the correct number of messages is displayed
9. Take note of one of the message IDs
10. Replace test.php with the following:
```
<?php

require_once('config.php');

$variant = get_config('tool_messagebroker', 'datastore');
$dao = tool_messagebroker\message\durable_dao_factory::make_durable_dao($variant);
$messages = $dao->mark_message_as_processed('2');
```
11. Repace the '2' with the ID from step 9
12. Refresh test.php
13. Inspet the DB and **verify** the correct message has the completed flag set
14. Revert the script back to what it was in step 5
15. Change the test script to retrieve 100 messages (or some number more than the total number of messages in the DB)
16. Reload the script
17. **Verify** the message with the completed flag set to 1 is **not** in the list
18. Change the test script to:
```
<?php

require_once('config.php');

$variant = get_config('tool_messagebroker', 'datastore');
$dao = tool_messagebroker\message\durable_dao_factory::make_durable_dao($variant);
$dao->purge_completed_messages();
```
19. Run the test script (there should be no output)
20. Inspect the DB and **verify** the message with the completed flag set to 1 has been deleted

Fixes #3 Fixes #7 