### PR TITLE
Added dummy message receivers

### DIFF
--- a/classes/event/test_message_received.php
+++ b/classes/event/test_message_received.php
@@ -1,0 +1,37 @@
+<?php
+namespace tool_messagebroker\event;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Dummy event for testing message broker receiving.
+ *
+ * It's not advised to log every message as an event
+ * at the message broker level because it may add
+ * significant load to the system.
+ *
+ * If you want to do this then feel free to add an
+ * all topics receiver to your plugin and have it
+ * emit events.
+ *
+ * @package   tool_messagebroker
+ * @copyright 2023 Monash University
+ * @author    Darren Cocco <darren.cocco@monash.edu>
+ */
+class test_message_received extends \core\event\base {
+
+    protected function init() {
+        $this->data['crud'] = 'r';
+        $this->data['edulevel'] = self::LEVEL_OTHER;
+    }
+
+    public static function get_name() {
+        return get_string('eventtestmessagereceived', 'tool_messagebroker');
+    }
+
+    public function get_description() {
+        return "The user with id '$this->userid' has sent a {$this->data['other']['type']} type message with the content:\n" .
+            "Topic: {$this->data['other']['topic']}\n".
+            "Body:\n" . json_encode($this->data['other']['body'], JSON_PRETTY_PRINT);
+    }
+}

--- a/classes/receiver/dummy_durable.php
+++ b/classes/receiver/dummy_durable.php
@@ -1,0 +1,43 @@
+<?php
+namespace tool_messagebroker\receiver;
+
+defined('MOODLE_INTERNAL') || die();
+
+use tool_messagebroker\event\test_message_received;
+use tool_messagebroker\message\immutable_message;
+
+/**
+ * Dummy durable receiver for testing
+ *
+ * @package   tool_messagebroker
+ * @copyright 2023 Monash University
+ * @author    Darren Cocco <darren.cocco@monash.edu>
+ */
+class dummy_durable implements message_receiver {
+
+    public static function instance(): message_receiver {
+        return new self;
+    }
+
+    public function process_message(immutable_message $message): bool {
+        global $USER;
+        test_message_received::create([
+            'userid' => $USER->id,
+            'context' => \context_system::instance(),
+            'other' => [
+                'type' => $this->get_preferred_message_processing_method(),
+                'topic' => $message->get_topic(),
+                'body' => $message->get_body()
+            ]
+        ])->trigger();
+        return true;
+    }
+
+    public function get_preferred_message_processing_method(): string {
+        return processing_style::DURABLE;
+    }
+
+    public function get_registered_topic(): string {
+        return '/^Dummy\.Durable/';
+    }
+}

--- a/classes/receiver/dummy_ephemeral.php
+++ b/classes/receiver/dummy_ephemeral.php
@@ -1,0 +1,43 @@
+<?php
+namespace tool_messagebroker\receiver;
+
+defined('MOODLE_INTERNAL') || die();
+
+use tool_messagebroker\event\test_message_received;
+use tool_messagebroker\message\immutable_message;
+
+/**
+ * Dummy ephemeral receiver for testing
+ *
+ * @package   tool_messagebroker
+ * @copyright 2023 Monash University
+ * @author    Darren Cocco <darren.cocco@monash.edu>
+ */
+class dummy_ephemeral implements message_receiver {
+
+    public static function instance(): message_receiver {
+        return new self;
+    }
+
+    public function process_message(immutable_message $message): bool {
+        global $USER;
+        test_message_received::create([
+            'userid' => $USER->id,
+            'context' => \context_system::instance(),
+            'other' => [
+                'type' => $this->get_preferred_message_processing_method(),
+                'topic' => $message->get_topic(),
+                'body' => $message->get_body()
+            ]
+        ])->trigger();
+        return true;
+    }
+
+    public function get_preferred_message_processing_method(): string {
+        return processing_style::EPHEMERAL;
+    }
+
+    public function get_registered_topic(): string {
+        return '/^Dummy\.Ephemeral/';
+    }
+}

--- a/lang/en/tool_messagebroker.php
+++ b/lang/en/tool_messagebroker.php
@@ -24,3 +24,4 @@ $string['processingstyle:ephemeral'] = 'Ephemeral';
 $string['processingstyle:receiver_preference'] = 'Receiver preference';
 $string['receivemode'] = 'Message receiving mode';
 $string['receivemode_help'] = 'Specifies how receivers will be treated when a message enters the system. When a value is selected, all receivers will be sent messages through the selected process (ephemeral/durable). When set to "Receiver preference" then the receivers preferred method will be used.<ul><li>Ephemeral: Receiver will receive and be required to process the message the before the message is confirmed as received by Moodle (Moodle doesn\'t retry these receivers).</li><li>Durable: Receiver will receive and process the message in the background (Moodle will continue to retry the message internally until the receiver gives a positive response).</li></ul>';
+$string['eventtestmessagereceived'] = 'Message Broker Test';

--- a/messagebroker.php
+++ b/messagebroker.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Dummy receiver provider for testing.
+ *
+ * @package   tool_messagebroker
+ * @copyright 2023 Monash University
+ * @author    Darren Cocco <darren.cocco@monash.edu>
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * @return tool_messagebroker\receiver\message_receiver[]
+ */
+function tool_messagebroker_build_message_receivers(): array {
+    return [
+        \tool_messagebroker\receiver\dummy_durable::instance(),
+        \tool_messagebroker\receiver\dummy_ephemeral::instance()
+    ];
+}


### PR DESCRIPTION
For testing the following curl command will work:
```
curl --request POST \
--data 'topic=Dummy.Ephemeral&body={"Banana": "Delicious"}' \
'http://www.moodle.test.docker/webservice/rest/server.php?wstoken=49b50ab7304457813f66e3f841eeda92&wsfunction=mbconnector_webservice_submit_message&moodlewsrestformat=json'
```

Just change the topic from `Dummy.Ephemeral` to `Dummy.Durable` to test the Durable message processing path