### PR TITLE
Move location of durable message cleaner task

### DIFF
--- a/datastores/standarddb/classes/task/durable_message_cleaner.php
+++ b/datastores/standarddb/classes/task/durable_message_cleaner.php
@@ -1,7 +1,8 @@
 <?php
-namespace mbdatastore_standarddb;
+namespace mbdatastore_standarddb\task;
 
 use core\task\scheduled_task;
+use mbdatastore_standarddb\durable_dao_factory;
 
 class durable_message_cleaner extends scheduled_task {
 

--- a/datastores/standarddb/db/tasks.php
+++ b/datastores/standarddb/db/tasks.php
@@ -1,7 +1,7 @@
 <?php
 $tasks = [
     [
-        'classname' => 'mbdatastore_standarddb\durable_message_cleaner',
+        'classname' => 'mbdatastore_standarddb\task\durable_message_cleaner',
         'blocking' => 0,
         'minute' => 'R',
         'hour' => '*/3',

--- a/datastores/standarddb/version.php
+++ b/datastores/standarddb/version.php
@@ -3,6 +3,6 @@ defined('MOODLE_INTERNAL') || die();
 
 /** @var stdClass $plugin */
 $plugin->component = 'mbdatastore_standarddb';
-$plugin->version = 2023060500;
+$plugin->version = 2023090400;
 $plugin->requires = 2020061505;
 $plugin->maturity = MATURITY_ALPHA;


### PR DESCRIPTION
# Testing

**NB**: Testing instructions assume a fresh install

1. Run the durable_message_processor task: `php admin/cli/scheduled_task.php --execute="\\tool_messagebroker\\task\\durable_message_processor"`
2. Put the following script in to the root of any plugin and call it messagebroker.php:
```
<?php

class receiver implements tool_messagebroker\receiver\message_receiver {
    private string $topic;
    private string $style;
    private string $willsucceed;

    public function __construct(string $topic, string $style, bool $willsucceed) {
        $this->topic = $topic;
        $this->style = $style;
        $this->willsucceed = $willsucceed;
    }

    public static function instance(): self {
        return new self();
    }

    public function process_message(tool_messagebroker\message\immutable_message $message): bool {
        return $this->willsucceed;
    }

    public function get_preferred_message_processing_method(): string {
        return $this->style;
    }

    public function get_registered_topic(): string {
        return "/" . $this->topic . "/";
    }
}

function [FRANKENSTYLE PREFIX]_build_message_receivers() {
    return [
        new receiver('movies', tool_messagebroker\receiver\processing_style::DURABLE, true)
    ];
}
```
4. Purge caches
5. Set up web services (ensure the role assigned to the web service user has the capability `tool/messagebroker:submitmessage`
6. Make a curl request to get a message in the system: `curl 'http://localhost/m/stable_401/webservice/rest/server.php?moodlewsrestformat=json' --data 'wsfunction=mbconnector_webservice_submit_message&topic=cool.movies&body=%7B%22some%22%3A%22thing%22%7D&wstoken=WS_TOKEN_HERE'`
7. Run the scheduled task to process it:  `php admin/cli/scheduled_task.php --execute="\\tool_messagebroker\\task\\durable_message_processor"`
8. Inspect the DB and **verify** there is a row for the message in the mdl_mbdatastore_standarddb_msg table with the completed flag set to 0
9. Run the cleaner task: `php admin/cli/scheduled_task.php --execute="\\mbdatastore_standarddb\\task\\durable_message_cleaner"`
10. Inspect the DB and **verify** the message has been removed

Fixes #17 