### PR TITLE
Use array of instances for message processor singleton

### DIFF
--- a/classes/message_processor.php
+++ b/classes/message_processor.php
@@ -20,13 +20,16 @@ class message_processor {
 
     private string $receivermode;
 
-    private static ?message_processor $instance = null;
+    private static array $instances = [];
 
     public static function instance(string $receivermode, ?durable_dao_interface $dao = null): self {
-        if (is_null(self::$instance)) {
-            self::$instance = new message_processor($receivermode, $dao);
+        $instancehash = $receivermode . '_' . ($dao ? spl_object_hash($dao) : 'default');
+
+        if (!isset(self::$instances[$instancehash])) {
+            self::$instances[$instancehash] = new message_processor($receivermode, $dao);
         }
-        return self::$instance;
+
+        return self::$instances[$instancehash];
     }
 
     protected function __construct(string $receivermode, ?durable_dao_interface $dao = null) {


### PR DESCRIPTION
# Testing
1. Add the following to the root of your install, call it test.php:
```
<?php

require_once('config.php');

$mode = get_config('tool_messagebroker', 'receivemode');
$dao = tool_messagebroker\message\durable_dao_factory::make_durable_dao('standarddb');
$anotherdao = tool_messagebroker\message\durable_dao_factory::make_durable_dao('standarddb');

echo '<pre>';
echo spl_object_hash(tool_messagebroker\message_processor::instance($mode)) . "\n";
echo spl_object_hash(tool_messagebroker\message_processor::instance($mode)) . "\n";
echo '</pre>';

echo '<pre>';
echo spl_object_hash(tool_messagebroker\message_processor::instance($mode, $dao)) . "\n";
echo spl_object_hash(tool_messagebroker\message_processor::instance($mode, $dao)) . "\n";
echo '</pre>';

echo '<pre>';
echo spl_object_hash(tool_messagebroker\message_processor::instance($mode, $anotherdao)) . "\n";
echo spl_object_hash(tool_messagebroker\message_processor::instance($mode, $anotherdao)) . "\n";
echo '</pre>';
```
2. Brows to http://[YOUR MOODLE]/test.php
3. **Verify** the output looks like:
```
000000001a695d400000000065fbf93c
000000001a695d400000000065fbf93c

000000001a695d4e0000000065fbf93c
000000001a695d4e0000000065fbf93c

000000001a695d480000000065fbf93c
000000001a695d480000000065fbf93c
```

Note that specific hashes aren't important. What's important is that each pair is identical (and different to other pairs).

Fixes #16 