### PR TITLE
issue #22: add missing lang strings

### DIFF
--- a/lang/en/tool_messagebroker.php
+++ b/lang/en/tool_messagebroker.php
@@ -14,6 +14,7 @@ defined('MOODLE_INTERNAL') || die();
 
 $string['datastore'] = 'Datastore plugin';
 $string['datastore_help'] = 'The selected datastore plugin will be used for persisting data associated with messages.';
+$string['eventtestmessagereceived'] = 'Message Broker Test';
 $string['messagebroker:submitmessage'] = "Submit a message to the Message Broker";
 $string['messagespertask'] = 'Messages per task';
 $string['messagespertask_help'] = 'The maximum number of messages which will be processed per execution of the Durable Message Processor task.';
@@ -24,4 +25,7 @@ $string['processingstyle:ephemeral'] = 'Ephemeral';
 $string['processingstyle:receiver_preference'] = 'Receiver preference';
 $string['receivemode'] = 'Message receiving mode';
 $string['receivemode_help'] = 'Specifies how receivers will be treated when a message enters the system. When a value is selected, all receivers will be sent messages through the selected process (ephemeral/durable). When set to "Receiver preference" then the receivers preferred method will be used.<ul><li>Ephemeral: Receiver will receive and be required to process the message the before the message is confirmed as received by Moodle (Moodle doesn\'t retry these receivers).</li><li>Durable: Receiver will receive and process the message in the background (Moodle will continue to retry the message internally until the receiver gives a positive response).</li></ul>';
-$string['eventtestmessagereceived'] = 'Message Broker Test';
+$string['subplugintype_mbconnector'] = 'Connector plugin';
+$string['subplugintype_mbconnector_plural'] = 'Connector plugins';
+$string['subplugintype_mbdatastore'] = 'Datastore plugin';
+$string['subplugintype_mbdatastore_plural'] = 'Datastore plugins';

--- a/version.php
+++ b/version.php
@@ -3,6 +3,6 @@ defined('MOODLE_INTERNAL') || die();
 
 /** @var stdClass $plugin */
 $plugin->component = 'tool_messagebroker';
-$plugin->version   = 2023090100;
+$plugin->version   = 2023090101;
 $plugin->requires  = 2020061505;
 $plugin->maturity  = MATURITY_ALPHA;


### PR DESCRIPTION
With the fix applied

```
vendor/bin/phpunit --testsuite tool_dataprivacy_testsuite
Moodle 4.5.1+ (Build: 20250109), 089260c29e12f642099be881a117dcdbaae96aad
Php: 8.1.29, pgsql: 16.0 (Debian 16.0-1.pgdg120+1), OS: Linux 6.8.0-51-generic x86_64
PHPUnit 9.6.18 by Sebastian Bergmann and contributors.

...............................................................  63 / 323 ( 19%)
............................................................... 126 / 323 ( 39%)
............................................................... 189 / 323 ( 58%)
............................................................... 252 / 323 ( 78%)
............................................................... 315 / 323 ( 97%)
........                                                        323 / 323 (100%)

Time: 01:27.292, Memory: 170.00 MB

OK (323 tests, 1330 assertions)
```
