### PR TITLE
issue #24: require externallib.php

### DIFF
--- a/connectors/webservice/classes/external/receive_message.php
+++ b/connectors/webservice/classes/external/receive_message.php
@@ -10,6 +10,10 @@ use tool_messagebroker\message\received_message;
 use tool_messagebroker\message_processor;
 use tool_messagebroker\receiver\processing_style;
 
+defined('MOODLE_INTERNAL') || die();
+
+require_once($CFG->libdir . '/externallib.php');
+
 class receive_message extends external_api {
 
     public static function execute(string $topic, string $body) {


### PR DESCRIPTION
Before the fix:

```
root@6548f6ade27a:/var/www/moodle45# vendor/bin/phpunit lib/external/tests/external_api_test.php
Moodle 4.5.1+ (Build: 20250109), a6774fab906abdb2227cd6e63534c6eb8873f4d9
Php: 8.1.29, pgsql: 16.0 (Debian 16.0-1.pgdg120+1), OS: Linux 6.8.0-51-generic x86_64
PHPUnit 9.6.18 by Sebastian Bergmann and contributors.

.......................................

Time: 23:50.616, Memory: 105.50 MB

There was 1 error:

1) core_external\external_api_test::test_all_external_info with data set "mbconnector_webservice_submit_message" (stdClass Object (...))
Error: Class "external_api" not found

/var/www/moodle45/admin/tool/messagebroker/connectors/webservice/classes/external/receive_message.php:13
/var/www/moodle45/lib/classes/component.php:217
/var/www/moodle45/lib/external/classes/external_api.php:62
/var/www/moodle45/lib/external/tests/external_api_test.php:400
/var/www/moodle45/lib/phpunit/classes/advanced_testcase.php:76

ERRORS!
Tests: 961, Assertions: 5720, Errors: 1.
```

After the fix:

```
vendor/bin/phpunit lib/external/tests/external_api_test.php
Moodle 4.5.1+ (Build: 20250109), a6774fab906abdb2227cd6e63534c6eb8873f4d9
Php: 8.1.29, pgsql: 16.0 (Debian 16.0-1.pgdg120+1), OS: Linux 6.8.0-51-generic x86_64
PHPUnit 9.6.18 by Sebastian Bergmann and contributors.

.....................

Time: 24:05.487, Memory: 105.50 MB

OK (961 tests, 5726 assertions)
```
